### PR TITLE
Configurable directory for response and exception dumps

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Will be used by https://github.com/oda-hub/dispatcher-plugin-integral to not clutter the scratch directory